### PR TITLE
Don't store the minhash implementation version in the db

### DIFF
--- a/src/us/kbase/assemblyhomology/load/NamespaceLoadInfo.java
+++ b/src/us/kbase/assemblyhomology/load/NamespaceLoadInfo.java
@@ -24,7 +24,7 @@ import us.kbase.assemblyhomology.core.exceptions.IllegalParameterException;
 import us.kbase.assemblyhomology.core.exceptions.MissingParameterException;
 import us.kbase.assemblyhomology.load.exceptions.LoadInputParseException;
 import us.kbase.assemblyhomology.minhash.MinHashDBLocation;
-import us.kbase.assemblyhomology.minhash.MinHashImplementationInformation;
+import us.kbase.assemblyhomology.minhash.MinHashImplementationName;
 import us.kbase.assemblyhomology.minhash.MinHashParameters;
 import us.kbase.assemblyhomology.minhash.MinHashSketchDatabase;
 
@@ -141,7 +141,7 @@ public class NamespaceLoadInfo {
 		
 		System.out.println(nsload.toNamespace(
 				new MinHashSketchDatabase(
-						new MinHashImplementationInformation("foo", "1"),
+						new MinHashImplementationName("foo"),
 						MinHashParameters.getBuilder(31).withSketchSize(10).build(),
 						new MinHashDBLocation(Paths.get("/tmp/fake")),
 						3),

--- a/src/us/kbase/assemblyhomology/minhash/MinHashImplementationInformation.java
+++ b/src/us/kbase/assemblyhomology/minhash/MinHashImplementationInformation.java
@@ -1,5 +1,6 @@
 package us.kbase.assemblyhomology.minhash;
 
+import static com.google.common.base.Preconditions.checkNotNull;
 import static us.kbase.assemblyhomology.util.Util.exceptOnEmpty;
 
 public class MinHashImplementationInformation {
@@ -7,19 +8,19 @@ public class MinHashImplementationInformation {
 	//TODO JAVADOC
 	//TODO TEST
 	
-	private final String implementationName;
+	private final MinHashImplementationName implementationName;
 	private final String implementationVersion;
 	
 	public MinHashImplementationInformation(
-			final String implementationName,
+			final MinHashImplementationName implementationName,
 			final String implementationVersion) {
-		exceptOnEmpty(implementationName, "implementationName");
+		checkNotNull(implementationName, "implementationName");
 		exceptOnEmpty(implementationVersion, "implementationVersion");
 		this.implementationName = implementationName;
 		this.implementationVersion = implementationVersion;
 	}
 
-	public String getImplementationName() {
+	public MinHashImplementationName getImplementationName() {
 		return implementationName;
 	}
 
@@ -30,7 +31,7 @@ public class MinHashImplementationInformation {
 	@Override
 	public String toString() {
 		StringBuilder builder = new StringBuilder();
-		builder.append("MinHashImplemenationInformation [implementationName=");
+		builder.append("MinHashImplementationInformation [implementationName=");
 		builder.append(implementationName);
 		builder.append(", implementationVersion=");
 		builder.append(implementationVersion);

--- a/src/us/kbase/assemblyhomology/minhash/MinHashImplementationName.java
+++ b/src/us/kbase/assemblyhomology/minhash/MinHashImplementationName.java
@@ -1,17 +1,17 @@
-package us.kbase.assemblyhomology.core;
+package us.kbase.assemblyhomology.minhash;
 
+import us.kbase.assemblyhomology.core.Name;
 import us.kbase.assemblyhomology.core.exceptions.IllegalParameterException;
 import us.kbase.assemblyhomology.core.exceptions.MissingParameterException;
 
-public class NamespaceID extends Name {
+public class MinHashImplementationName extends Name {
 
 	//TODO JAVADOC
 	//TODO TEST
 	
-	//TODO NOW ascii letters and numerals only
-	
-	public NamespaceID(final String id)
+	public MinHashImplementationName(final String id)
 			throws MissingParameterException, IllegalParameterException {
-		super(id, "namespaceID", 256);
+		super(id, "minhash implementation name", 256);
 	}
+	
 }

--- a/src/us/kbase/assemblyhomology/minhash/MinHashSketchDatabase.java
+++ b/src/us/kbase/assemblyhomology/minhash/MinHashSketchDatabase.java
@@ -3,7 +3,6 @@ package us.kbase.assemblyhomology.minhash;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import us.kbase.assemblyhomology.minhash.MinHashDBLocation;
-import us.kbase.assemblyhomology.minhash.MinHashImplementationInformation;
 import us.kbase.assemblyhomology.minhash.MinHashParameters;
 
 public class MinHashSketchDatabase {
@@ -11,30 +10,30 @@ public class MinHashSketchDatabase {
 	//TODO TEST
 	//TODO JAVADOC
 
-	private final MinHashImplementationInformation info;
+	private final MinHashImplementationName minHashImplementationName;
 	private final MinHashParameters parameterSet;
 	private final MinHashDBLocation location;
 	private final int sequenceCount;
 	
 	public MinHashSketchDatabase(
-			final MinHashImplementationInformation info,
+			final MinHashImplementationName minHashImplName,
 			final MinHashParameters parameterSet,
 			final MinHashDBLocation location,
 			final int sequenceCount) {
-		checkNotNull(info, "info");
+		checkNotNull(minHashImplName, "minHashImplName");
 		checkNotNull(parameterSet, "parameterSet");
 		checkNotNull(location, "location");
 		if (sequenceCount < 1) {
 			throw new IllegalArgumentException("sequenceCount must be at least 1");
 		}
-		this.info = info;
+		this.minHashImplementationName = minHashImplName;
 		this.parameterSet = parameterSet;
 		this.location = location;
 		this.sequenceCount = sequenceCount;
 	}
 
-	public MinHashImplementationInformation getImplementationInformation() {
-		return info;
+	public MinHashImplementationName getImplementationName() {
+		return minHashImplementationName;
 	}
 	
 	public MinHashParameters getParameterSet() {
@@ -50,13 +49,11 @@ public class MinHashSketchDatabase {
 	}
 	
 	public void checkCompatibility(final MinHashSketchDatabase otherDB) {
-		if (!getImplementationInformation().getImplementationName().equals(
-				otherDB.getImplementationInformation().getImplementationName())) {
+		if (!getImplementationName().equals(otherDB.getImplementationName())) {
 			// need to check version?
 			throw new IllegalArgumentException(String.format(
 					"Implementations for databases do not match: {} {}",
-					getImplementationInformation().getImplementationName(),
-					otherDB.getImplementationInformation().getImplementationName()));
+					getImplementationName(), otherDB.getImplementationName()));
 		}
 		if (!getParameterSet().equals(otherDB.getParameterSet())) {
 			/* is this check necessary? what happens if you run with differing
@@ -77,8 +74,8 @@ public class MinHashSketchDatabase {
 	@Override
 	public String toString() {
 		StringBuilder builder = new StringBuilder();
-		builder.append("MinHashSketchDatabase [info=");
-		builder.append(info);
+		builder.append("MinHashSketchDatabase [minHashImplementationName=");
+		builder.append(minHashImplementationName);
 		builder.append(", parameterSet=");
 		builder.append(parameterSet);
 		builder.append(", location=");

--- a/src/us/kbase/assemblyhomology/minhash/mash/Mash.java
+++ b/src/us/kbase/assemblyhomology/minhash/mash/Mash.java
@@ -19,10 +19,13 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.io.IOUtils;
 
+import us.kbase.assemblyhomology.core.exceptions.IllegalParameterException;
+import us.kbase.assemblyhomology.core.exceptions.MissingParameterException;
 import us.kbase.assemblyhomology.minhash.MinHashDBLocation;
 import us.kbase.assemblyhomology.minhash.MinHashDistance;
 import us.kbase.assemblyhomology.minhash.MinHashDistanceSet;
 import us.kbase.assemblyhomology.minhash.MinHashImplementationInformation;
+import us.kbase.assemblyhomology.minhash.MinHashImplementationName;
 import us.kbase.assemblyhomology.minhash.MinHashImplementation;
 import us.kbase.assemblyhomology.minhash.MinHashParameters;
 import us.kbase.assemblyhomology.minhash.MinHashSketchDatabase;
@@ -33,6 +36,8 @@ public class Mash implements MinHashImplementation {
 	
 	//TODO JAVADOC
 	//TODO TEST
+	
+	//TODO ZZLATER CODE consider JNA to bind directly to the mash libs? That would allow controlling the version of Mash.
 	
 	private final static String MASH = "mash";
 	
@@ -53,9 +58,12 @@ public class Mash implements MinHashImplementation {
 	private MinHashImplementationInformation getInfo() throws MinHashInitException {
 		try {
 			final String version = getVersion(getMashOutput("-h"));
-			return new MinHashImplementationInformation(MASH, version);
+			return new MinHashImplementationInformation(
+					new MinHashImplementationName(MASH), version);
 		} catch (MashException e) {
 			throw new MinHashInitException(e.getMessage(), e);
+		} catch (IllegalParameterException | MissingParameterException e) {
+			throw new RuntimeException("Well this is unexpected", e);
 		}
 	}
 	
@@ -119,7 +127,8 @@ public class Mash implements MinHashImplementation {
 			throws MashException {
 		checkNotNull(location, "location");
 		final ParamsAndSize pns = getParametersAndSize(location.getPathToFile().get());
-		return new MinHashSketchDatabase(info, pns.params, location, pns.size);
+		return new MinHashSketchDatabase(
+				info.getImplementationName(), pns.params, location, pns.size);
 	}
 	
 	@Override
@@ -236,7 +245,7 @@ public class Mash implements MinHashImplementation {
 		
 		final MinHashSketchDatabase db = mash.getDatabase(new MinHashDBLocation(Paths.get(
 				"/home/crusherofheads/kb_refseq_sourmash/kb_refseq_ci_1000.msh")));
-		System.out.println(db.getImplementationInformation());
+		System.out.println(db.getImplementationName());
 		System.out.println(db.getLocation());
 		System.out.println(db.getParameterSet());
 		System.out.println(db.getSequenceCount());
@@ -246,7 +255,7 @@ public class Mash implements MinHashImplementation {
 		
 		final MinHashSketchDatabase query = mash.getDatabase(new MinHashDBLocation(Paths.get(
 				"/home/crusherofheads/kb_refseq_sourmash/kb_refseq_ci_1000_15792_446_1.msh")));
-		System.out.println(query.getImplementationInformation());
+		System.out.println(query.getImplementationName());
 		System.out.println(query.getLocation());
 		System.out.println(query.getParameterSet());
 		System.out.println(query.getSequenceCount());

--- a/src/us/kbase/assemblyhomology/storage/mongo/MongoAssemblyHomologyStorage.java
+++ b/src/us/kbase/assemblyhomology/storage/mongo/MongoAssemblyHomologyStorage.java
@@ -42,6 +42,7 @@ import us.kbase.assemblyhomology.core.exceptions.NoSuchNamespaceException;
 import us.kbase.assemblyhomology.core.exceptions.NoSuchSequenceException;
 import us.kbase.assemblyhomology.minhash.MinHashDBLocation;
 import us.kbase.assemblyhomology.minhash.MinHashImplementationInformation;
+import us.kbase.assemblyhomology.minhash.MinHashImplementationName;
 import us.kbase.assemblyhomology.minhash.MinHashParameters;
 import us.kbase.assemblyhomology.minhash.MinHashSketchDatabase;
 import us.kbase.assemblyhomology.storage.AssemblyHomologyStorage;
@@ -252,9 +253,7 @@ public class MongoAssemblyHomologyStorage implements AssemblyHomologyStorage {
 				.append(Fields.NAMESPACE_DATABASE_ID, namespace.getSourceDatabaseID())
 				.append(Fields.NAMESPACE_DESCRIPTION, namespace.getDescription().orNull())
 				.append(Fields.NAMESPACE_IMPLEMENTATION,
-						sketchDB.getImplementationInformation().getImplementationName())
-				.append(Fields.NAMESPACE_IMPLEMENTATION_VERSION,
-						sketchDB.getImplementationInformation().getImplementationVersion())
+						sketchDB.getImplementationName().getName())
 				.append(Fields.NAMESPACE_KMER_SIZE, sketchDB.getParameterSet().getKmerSize())
 				.append(Fields.NAMESPACE_SKETCH_SIZE,
 						sketchDB.getParameterSet().getSketchSize().orNull())
@@ -292,9 +291,8 @@ public class MongoAssemblyHomologyStorage implements AssemblyHomologyStorage {
 			return Namespace.getBuilder(
 					namespace,
 					new MinHashSketchDatabase(
-							new MinHashImplementationInformation(
-									ns.getString(Fields.NAMESPACE_IMPLEMENTATION),
-									ns.getString(Fields.NAMESPACE_IMPLEMENTATION_VERSION)),
+							new MinHashImplementationName(
+									ns.getString(Fields.NAMESPACE_IMPLEMENTATION)),
 							buildParameters(ns),
 							new MinHashDBLocation(
 									Paths.get(ns.getString(Fields.NAMESPACE_SKETCH_DB_PATH))),
@@ -448,7 +446,7 @@ public class MongoAssemblyHomologyStorage implements AssemblyHomologyStorage {
 		final Namespace ns = Namespace.getBuilder(
 				new NamespaceID("foo"),
 				new MinHashSketchDatabase(
-						new MinHashImplementationInformation("Mash", "2.0"),
+						new MinHashImplementationName("Mash"),
 						MinHashParameters.getBuilder(31).withSketchSize(1000).build(),
 						new MinHashDBLocation(Paths.get("/tmp/fake")),
 						2400),
@@ -466,7 +464,7 @@ public class MongoAssemblyHomologyStorage implements AssemblyHomologyStorage {
 		final Namespace ns2 = Namespace.getBuilder(
 				new NamespaceID("foo"),
 				new MinHashSketchDatabase(
-						new MinHashImplementationInformation("Mash", "2.0"),
+						new MinHashImplementationName("Mash"),
 						MinHashParameters.getBuilder(31).withSketchSize(1000).build(),
 						new MinHashDBLocation(Paths.get("/tmp/fake2")),
 						2400),


### PR DESCRIPTION
The version depends on whatever version of the minhash implementation
(MHI) is available on the command line, which is not under the control
of the service. Also, since the sketch databases are provided by a user
and there's no way to know what version of the MHI was used to create
the database, assigning whatever version of the MHI happens to be
available on the command line to the namespace doesn't make any sense.