### PR TITLE
Allow query sketch size > target sketch size

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,12 +174,15 @@ List all namespaces.
 
 Returns information about a specific namespace.
 
-`POST /namespace/<namespace id>/search`
+`POST /namespace/<namespace id>/search[?notstrict]`
 
 Performs a search with the sketch database provided in the `POST` body against the sketch
 database associated with the namespace. `curl -T` is useful for this:  
 `curl -X POST -T kb_refseq_ci_1000_15792_446_1.msh http://localhost:20000/namespace/mynamespace/search`  
-Currently the input sketch database must contain only one sequence.
+Currently the input sketch database must contain only one sequence with a single kmer size.
+If `notstrict` is omitted, the server will return an error if the query sketch size is greater
+than the namespace sketch size. If `notstrict` is included, the server will return a warning
+instead. Any other parameter mismatches will result in an error.
 
 ## Developer notes
 

--- a/src/us/kbase/assemblyhomology/core/SequenceMatches.java
+++ b/src/us/kbase/assemblyhomology/core/SequenceMatches.java
@@ -1,6 +1,7 @@
 package us.kbase.assemblyhomology.core;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static us.kbase.assemblyhomology.util.Util.checkNoNullsOrEmpties;
 
 import java.util.Collections;
 import java.util.LinkedList;
@@ -17,17 +18,21 @@ public class SequenceMatches {
 	private final Namespace namespace;
 	private final MinHashImplementationInformation implementationInformation;
 	private final List<SequenceDistanceAndMetadata> distances;
+	private final List<String> warnings;
 	
 	public SequenceMatches(
 			final Namespace namespace,
 			final MinHashImplementationInformation implementationInformation,
-			final List<SequenceDistanceAndMetadata> distances) {
+			final List<SequenceDistanceAndMetadata> distances,
+			final List<String> warnings) {
 		checkNotNull(namespace, "namespace");
 		checkNotNull(implementationInformation, "implementationInformation");
 		checkNotNull(distances, "distances");
+		checkNoNullsOrEmpties(warnings, "warnings");
 		this.namespace = namespace;
 		this.implementationInformation = implementationInformation;
 		this.distances = Collections.unmodifiableList(new LinkedList<>(distances));
+		this.warnings = Collections.unmodifiableList(new LinkedList<>(warnings));
 	}
 
 	public Namespace getNamespace() {
@@ -41,6 +46,10 @@ public class SequenceMatches {
 	public List<SequenceDistanceAndMetadata> getDistances() {
 		return distances;
 	}
+	
+	public List<String> getWarnings() {
+		return warnings;
+	}
 
 	@Override
 	public String toString() {
@@ -51,6 +60,8 @@ public class SequenceMatches {
 		builder.append(implementationInformation);
 		builder.append(", distances=");
 		builder.append(distances);
+		builder.append(", warnings=");
+		builder.append(warnings);
 		builder.append("]");
 		return builder.toString();
 	}

--- a/src/us/kbase/assemblyhomology/minhash/MinHashDistanceSet.java
+++ b/src/us/kbase/assemblyhomology/minhash/MinHashDistanceSet.java
@@ -3,6 +3,8 @@ package us.kbase.assemblyhomology.minhash;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 
@@ -17,16 +19,19 @@ public class MinHashDistanceSet {
 	private final MinHashSketchDatabase reference;
 	// distance to the query sequence
 	private final Set<MinHashDistance> distances;
+	private final List<String> warnings;
 
 	// might want a builder here?
 	public MinHashDistanceSet(
 			final MinHashSketchDatabase query,
 			final MinHashSketchDatabase reference,
-			final Set<MinHashDistance> distances) {
+			final Set<MinHashDistance> distances,
+			final List<String> warnings) {
 		checkNotNull(query, "query");
 		checkNotNull(reference, "reference");
 		// check for duplicate sequence IDs?
 		Util.checkNoNullsInCollection(distances, "distances");
+		Util.checkNoNullsOrEmpties(warnings, "warnings");
 		if (query.getSequenceCount() != 1) { // may want to relax list later
 			throw new IllegalArgumentException("Query may only contain 1 sequence");
 		}
@@ -35,6 +40,7 @@ public class MinHashDistanceSet {
 		this.query = query;
 		this.reference = reference;
 		this.distances = Collections.unmodifiableSet(new TreeSet<>(distances));
+		this.warnings = Collections.unmodifiableList(new LinkedList<>(warnings));
 	}
 
 	public MinHashSketchDatabase getQuery() {
@@ -52,6 +58,10 @@ public class MinHashDistanceSet {
 	public Set<MinHashDistance> getDistances() {
 		return distances;
 	}
+	
+	public List<String> getWarnings() {
+		return warnings;
+	}
 
 	@Override
 	public String toString() {
@@ -62,6 +72,8 @@ public class MinHashDistanceSet {
 		builder.append(reference);
 		builder.append(", distances=");
 		builder.append(distances);
+		builder.append(", warnings=");
+		builder.append(warnings);
 		builder.append("]");
 		return builder.toString();
 	}

--- a/src/us/kbase/assemblyhomology/minhash/MinHashImplementation.java
+++ b/src/us/kbase/assemblyhomology/minhash/MinHashImplementation.java
@@ -22,7 +22,8 @@ public interface MinHashImplementation {
 	MinHashDistanceSet computeDistance(
 			MinHashSketchDatabase query,
 			MinHashSketchDatabase reference,
-			int maxReturnCount)
+			int maxReturnCount,
+			boolean strict)
 			throws MinHashException;
 	
 }

--- a/src/us/kbase/assemblyhomology/minhash/MinHashSketchDatabase.java
+++ b/src/us/kbase/assemblyhomology/minhash/MinHashSketchDatabase.java
@@ -2,8 +2,12 @@ package us.kbase.assemblyhomology.minhash;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import java.util.LinkedList;
+import java.util.List;
+
 import us.kbase.assemblyhomology.minhash.MinHashDBLocation;
 import us.kbase.assemblyhomology.minhash.MinHashParameters;
+import us.kbase.assemblyhomology.minhash.exceptions.MinHashException;
 
 public class MinHashSketchDatabase {
 	
@@ -48,28 +52,72 @@ public class MinHashSketchDatabase {
 		return sequenceCount;
 	}
 	
-	public void checkCompatibility(final MinHashSketchDatabase otherDB) {
-		if (!getImplementationName().equals(otherDB.getImplementationName())) {
+	/** Check if this database may be queried by another sketch database.
+	 * @param query the query database.
+	 * @param strict throw an exception for any mismatch in sketch database parameters if true. If
+	 * false, parameter differences that don't preclude a query will not throw an exception but
+	 * will return warnings. Some parameter differences (e.g. kmer size) will always cause an
+	 * exception to be thrown.
+	 * @return warnings regarding database parameter mismatches, if any.
+	 * @throws MinHashException if the database parameters don't match.
+	 */
+	public List<String> checkIsQueriableBy(final MinHashSketchDatabase query, final boolean strict)
+			throws MinHashException {
+		final List<String> warnings = new LinkedList<>();
+		if (!getImplementationName().equals(query.getImplementationName())) {
 			// need to check version?
-			throw new IllegalArgumentException(String.format(
-					"Implementations for databases do not match: {} {}",
-					getImplementationName(), otherDB.getImplementationName()));
+			throw new MinHashException(String.format(
+					"Implementations for sketches do not match: %s %s",
+					getImplementationName(), query.getImplementationName()));
 		}
-		if (!getParameterSet().equals(otherDB.getParameterSet())) {
-			//TODO NOW allow query sketch size > reference, but not reverse
-			/* is this check necessary? what happens if you run with differing
-			 * sketch sizes?
-			 * for mash:
-			 *		if the kmer size is different it skips the file
-			 * 		if the query hash count is < reference it skips the file
-			 *		if the query hash count is > reference, it warns and reduces the overall
-			 *		hash count
-			 *		either way we shouldn't allow it (maybe with explicit permission for the
-			 *		lower hash count, but then need to ignore the warning in the output)
-			 */
-			throw new IllegalArgumentException(
-					"Parameter sets for databases do not match");
+		final MinHashParameters rp = getParameterSet();
+		final MinHashParameters qp = query.getParameterSet();
+		//TODO FEATURE allow multiple kmer sizes
+		if (rp.getKmerSize() != qp.getKmerSize()) {
+			throw new MinHashException(String.format(
+					"Kmer size for sketches are not compatible: %s %s",
+					rp.getKmerSize(), qp.getKmerSize()));
 		}
+		if (rp.getScaling().isPresent() ^ qp.getScaling().isPresent()) { // xor
+			throw new MinHashException(
+					"Both sketches must use either absolute sketch counts or scaling");
+		}
+		if (rp.getScaling().isPresent()) {
+			// may need to adjust this when we have an implementation that supports scaling
+			if (!rp.getScaling().get().equals(qp.getScaling().get())) {
+				throw new MinHashException(String.format(
+						"Scaling paramters for sketches are not compatible: %s %s",
+						rp.getScaling().get(), qp.getScaling().get()));
+			}
+		} else {
+			if (!rp.getSketchSize().get().equals(qp.getSketchSize().get())) {
+				if (strict) {
+					throw new MinHashException(String.format(
+							"Query sketch size %s does not match target %s",
+							qp.getSketchSize().get(), rp.getSketchSize().get()));
+				}
+				if (qp.getSketchSize().get() > rp.getSketchSize().get()) {
+					warnings.add(String.format(
+							"Query sketch size %s is larger than target sketch size %s",
+							qp.getSketchSize().get(), rp.getSketchSize().get()));
+				} else {
+					throw new MinHashException(String.format(
+							"Query sketch size %s may not be smaller than the target sketch " +
+							"size %s",
+							qp.getSketchSize().get(), rp.getSketchSize().get()));
+				}
+			}
+		}
+		/*
+		 * when you run mash:
+		 *		if the kmer size is different it skips the file
+		 * 		if the query hash count is < reference it skips the file
+		 *		if the query hash count is > reference, it warns and reduces the overall
+		 *		hash count
+		 *		either way we shouldn't allow it (except with explicit permission for the
+		 *		reduced hash count)
+		 */
+		return warnings;
 	}
 
 	@Override

--- a/src/us/kbase/assemblyhomology/minhash/mash/Mash.java
+++ b/src/us/kbase/assemblyhomology/minhash/mash/Mash.java
@@ -211,15 +211,16 @@ public class Mash implements MinHashImplementation {
 	public MinHashDistanceSet computeDistance(
 			final MinHashSketchDatabase query,
 			final MinHashSketchDatabase reference,
-			final int maxReturnCount)
-			throws MashException {
+			final int maxReturnCount,
+			final boolean strict)
+			throws MinHashException {
 		checkNotNull(query, "query");
 		checkNotNull(reference, "reference");
 		if (query.getSequenceCount() != 1) {
 			// may want to relax this, but that'll require changing a bunch of stuff
 			throw new IllegalArgumentException("Only 1 query sequence is allowed");
 		}
-		query.checkCompatibility(reference);
+		final List<String> warnings = reference.checkIsQueriableBy(query, strict);
 		// may need to be smarter about this for really large collections
 		List<MinHashDistance> dists = processMashOutput(PROC, false, "dist", "-d", "0.5",
 					reference.getLocation().getPathToFile().get().toString(),
@@ -228,7 +229,7 @@ public class Mash implements MinHashImplementation {
 			Collections.sort(dists);
 			dists = dists.subList(0, maxReturnCount);
 		}
-		return new MinHashDistanceSet(query, reference, new HashSet<>(dists));
+		return new MinHashDistanceSet(query, reference, new HashSet<>(dists), warnings);
 	}
 	
 	private static class ParamsAndSize {
@@ -269,14 +270,14 @@ public class Mash implements MinHashImplementation {
 		System.out.println(ids);
 		
 		final MinHashSketchDatabase query = mash.getDatabase(new MinHashDBLocation(Paths.get(
-				"/home/crusherofheads/kb_refseq_sourmash/kb_refseq_ci_1000_15792_446_1.msh")));
+				"/home/crusherofheads/kb_refseq_sourmash/kb_refseq_ci_1000_15792_446_1_hashes1500.msh")));
 		System.out.println(query.getImplementationName());
 		System.out.println(query.getLocation());
 		System.out.println(query.getParameterSet());
 		System.out.println(query.getSequenceCount());
 		System.out.println(mash.getSketchIDs(query));
 		
-		final MinHashDistanceSet dists = mash.computeDistance(query, db, 30);
+		final MinHashDistanceSet dists = mash.computeDistance(query, db, 30, false);
 		System.out.println(dists);
 		System.out.println(dists.getDistances().size());
 	}

--- a/src/us/kbase/assemblyhomology/service/Fields.java
+++ b/src/us/kbase/assemblyhomology/service/Fields.java
@@ -38,6 +38,7 @@ public class Fields {
 	public static final String DIST_RELATED_IDS = "relatedids";
 	public static final String DIST_SCI_NAME = "sciname";
 	public static final String DIST_SOURCE_ID = "sourceid";
+	public static final String DIST_WARNINGS = "warnings";
 	
 	/* errors */
 	


### PR DESCRIPTION
User must specify allowing mismatched sketch sizes. Warns on mismatch.

Mash won't process sketches where kmer sizes aren't equivalent or query
size < target size.