### PR TITLE
SCT-967 Only keep <max return count> distances in memory

### DIFF
--- a/src/us/kbase/assemblyhomology/minhash/mash/Mash.java
+++ b/src/us/kbase/assemblyhomology/minhash/mash/Mash.java
@@ -149,6 +149,7 @@ public class Mash implements MinHashImplementation {
 	public List<String> getSketchIDs(final MinHashSketchDatabase db) throws MashException {
 		final List<String> ids = new LinkedList<>();
 		processMashOutput(
+				//TODO CODE make less brittle
 				l -> ids.add(l.split("\\s+")[2].trim()),
 				true,
 				"info", "-t", db.getLocation().getPathToFile().get().toString());

--- a/src/us/kbase/assemblyhomology/util/CappedTreeSet.java
+++ b/src/us/kbase/assemblyhomology/util/CappedTreeSet.java
@@ -1,0 +1,80 @@
+package us.kbase.assemblyhomology.util;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+public class CappedTreeSet<T extends Comparable<T>> {
+	
+	//TODO JAVADOC
+	//TODO TESTS
+
+	// for a generally useful implementation allow a comparator in the constructor
+	// and other constructors with default args other than size
+	
+	private final TreeSet<T> tree;
+	private final int size;
+	private final boolean descending;
+	
+	public CappedTreeSet(final int size, final boolean descending) {
+		if (size < 0) {
+			throw new IllegalArgumentException("size must be > 0");
+		}
+		tree = new TreeSet<>();
+		this.size = size;
+		this.descending = descending;
+	}
+	
+	public SortedSet<T> toSortedSet() {
+		return new TreeSet<>(tree);
+	}
+
+	public void add(final T item) {
+		checkNotNull(item, "item");
+		if (tree.size() < size) {
+			tree.add(item);
+		} else {
+			if (descending) {
+				if (tree.last().compareTo(item) > 0) {
+					tree.add(item);
+					tree.pollLast();
+				}
+			} else {
+				if (tree.first().compareTo(item) < 0) {
+					tree.add(item);
+					tree.pollFirst();
+				}
+			}
+		}
+	}
+	
+	@Override
+	public String toString() {
+		StringBuilder builder = new StringBuilder();
+		builder.append("CappedTreeSet [tree=");
+		builder.append(tree);
+		builder.append(", size=");
+		builder.append(size);
+		builder.append(", descending=");
+		builder.append(descending);
+		builder.append("]");
+		return builder.toString();
+	}
+	
+	public static void main(final String[] args) {
+		final CappedTreeSet<Integer> cts = new CappedTreeSet<>(3, false);
+		cts.add(10);
+		cts.add(5);
+		cts.add(20);
+		System.out.println(cts);
+		cts.add(30);
+		System.out.println(cts);
+		cts.add(4);
+		System.out.println(cts);
+		cts.add(15);
+		System.out.println(cts);
+		cts.add(7);
+		System.out.println(cts);
+	}
+}


### PR DESCRIPTION
Preparation for running mash against multiple files.

Adds a capped sorted collection that only performs a sort when a) the
collection size is below the cap or b) the item to be added to the
collection is larger than the smallest item in the collection (or vice
versa if descending is specified).

This is used to only keep the top \<max return count> distance
measurements in memory at any one time, and means the sort is now n log
\<max return count> rather than n log n. In practice many of the distance
measurements will be rejected immediately and no sort will occur.