### PR TITLE
SCT-966 Add MashFactory test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
   - git clone https://github.com/kbase/jars
   - wget https://github.com/marbl/Mash/releases/download/v2.0/mash-Linux64-v2.0.tar
   - tar -xzf mash-Linux64-v2.0.tar
-  - export PATH=$PATH:$PWD/mash-linux64-v2.0
+  - export PATH=$PATH:$PWD/mash-Linux64-v2.0
   - cd -
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,9 @@ before_install:
 install:
   - cd ..
   - git clone https://github.com/kbase/jars
+  - wget https://github.com/marbl/Mash/releases/download/v2.0/mash-Linux64-v2.0.tar
+  - tar -xzf mash-Linux64-v2.0.tar
+  - export PATH=$PATH:$PWD/mash-linux64-v2.0
   - cd -
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
   - cd ..
   - git clone https://github.com/kbase/jars
   - wget https://github.com/marbl/Mash/releases/download/v2.0/mash-Linux64-v2.0.tar
-  - tar -xzf mash-Linux64-v2.0.tar
+  - tar -xf mash-Linux64-v2.0.tar
   - export PATH=$PATH:$PWD/mash-Linux64-v2.0
   - cd -
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Most input strings do not allow empty strings and have a maximum size of 256 uni
 
 ## MinHash implementations
 
-Currently only [Mash](https://genomebiology.biomedcentral.com/articles/10.1186/s13059-016-0997-x)
+Currently only [Mash v2.0](https://genomebiology.biomedcentral.com/articles/10.1186/s13059-016-0997-x)
 is supported. Mash is configured to never return sequences with a distance greater than 0.5.
 
 ## Requirements

--- a/build.xml
+++ b/build.xml
@@ -257,6 +257,7 @@
         <classpath refid="test.classpath"/>
         <formatter type="plain" usefile="false" />
         <sysproperty key="ASSEMHOMOL_TEST_CONFIG" value="${testcfg}"/>
+        <test name="us.kbase.test.assemblyhomology.minhash.mash.MashFactoryTest"/>
         <test name="us.kbase.test.assemblyhomology.util.CappedTreeSetTest"/>
         <test name="us.kbase.test.assemblyhomology.util.PathRestreamableTest"/>
         <test name="us.kbase.test.assemblyhomology.util.UtilTest"/>

--- a/src/us/kbase/assemblyhomology/minhash/MinHashImplementationInformation.java
+++ b/src/us/kbase/assemblyhomology/minhash/MinHashImplementationInformation.java
@@ -41,6 +41,52 @@ public class MinHashImplementationInformation {
 	}
 
 	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((expectedFileExtension == null) ? 0 : expectedFileExtension.hashCode());
+		result = prime * result + ((implementationName == null) ? 0 : implementationName.hashCode());
+		result = prime * result + ((implementationVersion == null) ? 0 : implementationVersion.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null) {
+			return false;
+		}
+		if (getClass() != obj.getClass()) {
+			return false;
+		}
+		MinHashImplementationInformation other = (MinHashImplementationInformation) obj;
+		if (expectedFileExtension == null) {
+			if (other.expectedFileExtension != null) {
+				return false;
+			}
+		} else if (!expectedFileExtension.equals(other.expectedFileExtension)) {
+			return false;
+		}
+		if (implementationName == null) {
+			if (other.implementationName != null) {
+				return false;
+			}
+		} else if (!implementationName.equals(other.implementationName)) {
+			return false;
+		}
+		if (implementationVersion == null) {
+			if (other.implementationVersion != null) {
+				return false;
+			}
+		} else if (!implementationVersion.equals(other.implementationVersion)) {
+			return false;
+		}
+		return true;
+	}
+
+	@Override
 	public String toString() {
 		StringBuilder builder = new StringBuilder();
 		builder.append("MinHashImplementationInformation [implementationName=");

--- a/src/us/kbase/assemblyhomology/minhash/mash/Mash.java
+++ b/src/us/kbase/assemblyhomology/minhash/mash/Mash.java
@@ -76,6 +76,10 @@ public class Mash implements MinHashImplementation {
 		}
 		info = getInfo();
 	}
+	
+	public Path getTemporaryFileDirectory() {
+		return tempFileDirectory;
+	}
 
 	private MinHashImplementationInformation getInfo() throws MinHashInitException {
 		try {

--- a/src/us/kbase/assemblyhomology/minhash/mash/MashFactory.java
+++ b/src/us/kbase/assemblyhomology/minhash/mash/MashFactory.java
@@ -9,11 +9,12 @@ import us.kbase.assemblyhomology.minhash.MinHashImplementationFactory;
 import us.kbase.assemblyhomology.minhash.MinHashImplementationName;
 import us.kbase.assemblyhomology.minhash.exceptions.MinHashInitException;
 
+/** A factory for a Mash implementation of {@link MinHashImplementation}.
+ * @author gaprice@lbl.gov
+ *
+ */
 public class MashFactory implements MinHashImplementationFactory {
 
-	//TODO JAVADOC
-	//TODO TEST
-	
 	@Override
 	public MinHashImplementation getImplementation(final Path tempFileDirectory)
 			throws MinHashInitException {

--- a/src/us/kbase/test/assemblyhomology/minhash/mash/MashFactoryTest.java
+++ b/src/us/kbase/test/assemblyhomology/minhash/mash/MashFactoryTest.java
@@ -1,0 +1,47 @@
+package us.kbase.test.assemblyhomology.minhash.mash;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.Test;
+
+import com.google.common.base.Optional;
+
+import us.kbase.assemblyhomology.minhash.MinHashImplementationInformation;
+import us.kbase.assemblyhomology.minhash.MinHashImplementationName;
+import us.kbase.assemblyhomology.minhash.mash.Mash;
+import us.kbase.assemblyhomology.minhash.mash.MashFactory;
+import us.kbase.test.assemblyhomology.TestCommon;
+
+public class MashFactoryTest {
+
+	@Test
+	public void getImplementationName() throws Exception {
+		assertThat("incorrect name", new MashFactory().getImplementationName(),
+				is(new MinHashImplementationName("mash")));
+	}
+	
+	@Test
+	public void getExpectedFileExtension() throws Exception {
+		assertThat("incorrect exception", new MashFactory().getExpectedFileExtension(),
+				is(Optional.of(Paths.get("msh"))));
+	}
+	
+	@Test
+	public void getImplementation() throws Exception {
+		final Path temp = TestCommon.getTempDir();
+		
+		final Mash impl = (Mash) new MashFactory().getImplementation(temp);
+		
+		assertThat("incorrect temp dir", impl.getTemporaryFileDirectory(), is(temp));
+		assertThat("incorrect info", impl.getImplementationInformation(),
+				is(new MinHashImplementationInformation(
+						new MinHashImplementationName("mash"),
+						"2.0", // might need to be smarter about this
+						Paths.get("msh"))));
+	}
+	
+}

--- a/test.cfg.example
+++ b/test.cfg.example
@@ -1,4 +1,5 @@
 # To run tests, copy this file to test.cfg and set the values below appropriately.
+# Note that to run tests, the mash binary must be on the build path.
 
 [assemblyhomologytest]
 


### PR DESCRIPTION
Requires mash to be on the build path.